### PR TITLE
Contact area fix

### DIFF
--- a/examples/contact_area.py
+++ b/examples/contact_area.py
@@ -29,5 +29,33 @@ def extract_surface_contact():
     ImageHandler.save("surface_contact_2.png", sample_img_2)
 
 
+def extract_surface_contact_real_time():
+    """
+    This function demonstrates how to use the ContactArea task with real-time mode with DIGIT sensor.
+    Make sure to have a DIGIT sensor connected to your computer and setup the digit-interface library.
+    Output:
+        Displays a real-time object contact area by fitting an ellipse.
+    """
+    from digit_interface import Digit
+    import cv2
+    base_img_path = "/home/shuk/digits2/images/0000/0041.png"
+    base_img = ImageHandler(base_img_path).nparray
+    # setting up the DIGIT sensor
+    digit = Digit("Dxxxxx")  # replace xxxxx with your DIGIT serial number
+    digit.connect()
+    while True:
+        frame=digit.get_frame()
+        img=cv2.cvtColor(frame, cv2.COLOR_BGR2RGB) # target image frame for __call__ method
+        contact_area=ContactArea(base=base_img, contour_threshold=10,real_time=True)
+        contact_area(target=img) # __call__ method
+        cv2.imshow('surface contact', img)
+        k=cv2.waitKey(1)
+        if k%256==27:
+            #ESC hit
+            print("Escape hit, closing...")
+            break
+
+
 if __name__ == "__main__":
-    extract_surface_contact()
+    #extract_surface_contact()
+    extract_surface_contact_real_time()

--- a/examples/contact_area.py
+++ b/examples/contact_area.py
@@ -38,7 +38,7 @@ def extract_surface_contact_real_time():
     """
     from digit_interface import Digit
     import cv2
-    base_img_path = "/home/shuk/digits2/images/0000/0041.png"
+    base_img_path = "./path/to/img/"
     base_img = ImageHandler(base_img_path).nparray
     # setting up the DIGIT sensor
     digit = Digit("Dxxxxx")  # replace xxxxx with your DIGIT serial number

--- a/pytouch/tasks/contact_area.py
+++ b/pytouch/tasks/contact_area.py
@@ -10,11 +10,12 @@ _log = logging.getLogger(__name__)
 
 class ContactArea:
     def __init__(
-        self, base=None, draw_poly=True, contour_threshold=100, *args, **kwargs
+        self, base=None, draw_poly=True, contour_threshold=100,real_time=False,*args, **kwargs
     ):
         self.base = base
         self.draw_poly = draw_poly
         self.contour_threshold = contour_threshold
+        self.real_time = real_time
 
     def __call__(self, target, base=None):
         base = self.base if base is None else base
@@ -23,13 +24,18 @@ class ContactArea:
         diff = self._diff(target, base)
         diff = self._smooth(diff)
         contours = self._contours(diff)
-        (
-            poly,
-            major_axis,
-            major_axis_end,
-            minor_axis,
-            minor_axis_end,
-        ) = self._compute_contact_area(contours, self.contour_threshold)
+        if self._compute_contact_area(contours, self.contour_threshold) == None and self.real_time==False:
+            raise Exception("No contact area detected.")
+        if self._compute_contact_area(contours, self.contour_threshold) == None and self.real_time==True:
+            return None
+        else:
+            (
+                poly,
+                major_axis,
+                major_axis_end,
+                minor_axis,
+                minor_axis_end,
+            ) = self._compute_contact_area(contours, self.contour_threshold)
         if self.draw_poly:
             self._draw_major_minor(
                 target, poly, major_axis, major_axis_end, minor_axis, minor_axis_end
@@ -104,4 +110,4 @@ class ContactArea:
                 )
                 major_axis_end = 2 * center - major_axis
                 minor_axis_end = 2 * center - minor_axis
-        return poly, major_axis, major_axis_end, minor_axis, minor_axis_end
+                return poly, major_axis, major_axis_end, minor_axis, minor_axis_end


### PR DESCRIPTION
This is a proposed fix for #23 issue 2 and #22 [issue](https://github.com/facebookresearch/PyTouch/issues/22#issuecomment-1067517267)  
This PR solves the "UnboundLocalError: local variable 'poly' referenced before assignment" error when there is no object detected and throws an exception if real_time is False. When real_time is True, the exception is not raised and OpenCV contact screen continues showing up.
Also contained in this PR:
- a new variable **real_time** in pytouch/tasks/contact_area.py to differentiate if contact_area task is running real_time or only for one image
- a separete function extract_contact_area_real_time inside the script examples/contact_area.py to demonstrate the real-time contact area ellipse fitting with DIGIT sensor. Requires the setup of [digit-interface](https://github.com/facebookresearch/digit-interface) to run.

This is my first PR on Github. Let me know your thoughts and suggestions.